### PR TITLE
allow empty path to be matched

### DIFF
--- a/src/createNavigationContainer.js
+++ b/src/createNavigationContainer.js
@@ -96,7 +96,7 @@ export default function createNavigationContainer<T: *>(
       const params = {};
       const delimiter = this.props.uriPrefix || '://';
       let path = url.split(delimiter)[1];
-      if (!path) {
+      if (typeof path === 'undefined') {
         path = url;
       }
       return {


### PR DESCRIPTION
previously when opening a deeplink without a path, it would result in an array of 2 empty strings, which is are falsy values, so the full url was passed on.

by checking if the value is actually `undefined` instead of falsy we have no more false positives